### PR TITLE
Fix checkout item handling

### DIFF
--- a/frontend/src/components/products/ProductCatalog.jsx
+++ b/frontend/src/components/products/ProductCatalog.jsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { Eye, Heart, ShoppingBag } from 'lucide-react';
+import { Heart, ShoppingBag } from 'lucide-react';
 import { useProducts } from '../../context/ProductContext';
-import { useCart } from '../../context/CartContext';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 const ProductCatalog = () => {
   const [selectedCategory, setSelectedCategory] = useState('todos');
@@ -13,7 +12,7 @@ const ProductCatalog = () => {
     loading, 
     error 
   } = useProducts();
-  const { addItem } = useCart();
+  const navigate = useNavigate();
 
   // Carregar produtos quando categoria muda
   useEffect(() => {
@@ -87,11 +86,11 @@ const ProductCatalog = () => {
               <button className="bg-white/95 backdrop-blur-sm p-3 hover:bg-white transition-all duration-300">
                 <Heart className="w-4 h-4" strokeWidth={1} />
               </button>
-              <button 
+              <button
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
-                  addItem(product);
+                  navigate(`/produto/${product.slug || product._id || product.id}`);
                 }}
                 className="bg-white/95 backdrop-blur-sm p-3 hover:bg-white transition-all duration-300"
               >

--- a/frontend/src/context/CartContext.jsx
+++ b/frontend/src/context/CartContext.jsx
@@ -206,9 +206,18 @@ export const CartProvider = ({ children }) => {
       },
       configuration: {
         color: item.configuration?.color || item.selectedColor || 'Padrão',
-        installationType: item.configuration?.installationType || 'professional',
-        mounting: item.configuration?.mounting || 'ceiling',
-        includeSheer: item.configuration?.includeSheer || false
+        installationType:
+          item.configuration?.installationType ||
+          item.measurements?.installationType ||
+          'professional',
+        mounting:
+          item.configuration?.mounting ||
+          item.measurements?.mounting ||
+          'ceiling',
+        includeSheer:
+          item.configuration?.includeSheer ??
+          item.measurements?.includeSheer ??
+          false
       },
       quantity: item.quantity || 1
     }));


### PR DESCRIPTION
## Summary
- redirect catalog add-to-cart button to detail page so clients select measurements first
- preserve item configuration in CartContext when creating orders
- remove unused imports and ensure newline at EOF

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685687637bd883229d5c275ea60724f4